### PR TITLE
Add Copy Style button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@babel/preset-react": "^7.12.10",
         "@babel/preset-typescript": "^7.12.7",
         "@testing-library/react": "^9.5.0",
+        "@types/webpack-env": "^1.18.4",
         "babel-jest": "^24.9.0",
         "babel-loader": "^8.2.2",
         "css-loader": "^3.6.0",
@@ -42,7 +43,7 @@
         "jest": "^24.9.0",
         "style-loader": "^1.3.0",
         "ts-loader": "^7.0.5",
-        "typescript": "^3.9.7",
+        "typescript": "^3.9.10",
         "webpack": "^4.44.2",
         "webpack-cli": "^4.9.2",
         "webpack-dev-server": "^4.8.1"
@@ -2485,6 +2486,12 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
       "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+    },
+    "node_modules/@types/webpack-env": {
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.18.4.tgz",
+      "integrity": "sha512-I6e+9+HtWADAWeeJWDFQtdk4EVSAbj6Rtz4q8fJ7mSr1M0jzlFcs8/HZ+Xb5SHzVm1dxH7aUiI+A8kA8Gcrm0A==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.3",
@@ -15931,6 +15938,12 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
       "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+    },
+    "@types/webpack-env": {
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.18.4.tgz",
+      "integrity": "sha512-I6e+9+HtWADAWeeJWDFQtdk4EVSAbj6Rtz4q8fJ7mSr1M0jzlFcs8/HZ+Xb5SHzVm1dxH7aUiI+A8kA8Gcrm0A==",
+      "dev": true
     },
     "@types/ws": {
       "version": "8.5.3",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "rnacanvas",
   "version": "1.0.0",
-  "description": "",
+  "description": "A [web app](https://rnacanvas.app) for the interactive drawing of nucleic acid structures. Bases are automatically arranged to convey stems and loops and the layout of a drawing can be easily adjusted by dragging with the mouse. Drawings can be highly customized, including the fonts, colors and dimensions of elements and the outlines and numbering of bases. The entirety of the Leontis-Westhof notation for depicting canonical and non-canonical base-pairs is also supported. Drawings are exported in SVG and PowerPoint (PPTX) formats such that all elements of a drawing (e.g., bases and bonds) are exported as individual SVG and PowerPoint objects, allowing for further manipulation in a vector graphics editor such as Adobe Illustrator or PowerPoint.",
   "private": true,
   "scripts": {
     "test": "jest",
     "watch": "webpack --watch",
     "start": "webpack-dev-server --open",
-    "build": "webpack"
+    "build": "webpack",
+    "start2": "webpack-dev-server --open --hot --config webpack.dev.js"
   },
   "keywords": [],
   "author": "",
@@ -18,6 +19,7 @@
     "@babel/preset-react": "^7.12.10",
     "@babel/preset-typescript": "^7.12.7",
     "@testing-library/react": "^9.5.0",
+    "@types/webpack-env": "^1.18.4",
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.2.2",
     "css-loader": "^3.6.0",

--- a/src/draw/bases/Base.ts
+++ b/src/draw/bases/Base.ts
@@ -161,5 +161,6 @@ Base.recommendedDefaults = {
     'font-size': 9,
     'font-weight': 'bold',
     'font-style': 'normal',
+    'fill': 'black',
   },
 };

--- a/src/draw/bases/values.ts
+++ b/src/draw/bases/values.ts
@@ -6,6 +6,7 @@ export type Values = {
     'font-size'?: number;
     'font-weight'?: string | number;
     'font-style'?: string;
+    'fill'?: string;
   }
 }
 
@@ -53,6 +54,9 @@ export function setValues(b: Base, vs: Values) {
     }
     if (typeof vs.text['font-style'] == 'string') {
       b.text.attr({ 'font-style': vs.text['font-style'] });
+    }
+    if (typeof vs.text['fill'] == 'string') {
+      b.text.attr({ 'fill': vs.text['fill'] });
     }
   }
 }

--- a/src/draw/bonds/strung/create.ts
+++ b/src/draw/bonds/strung/create.ts
@@ -1,7 +1,7 @@
 import * as SVG from '@svgdotjs/svg.js';
 import { assignUuid } from 'Draw/svg/assignUuid';
 
-import type { StrungText } from 'Draw/bonds/strung/StrungElement';
+import type { StrungElement, StrungText } from 'Draw/bonds/strung/StrungElement';
 import type { StrungCircle } from 'Draw/bonds/strung/StrungElement';
 import type { StrungTriangle } from 'Draw/bonds/strung/StrungElement';
 import type { StrungRectangle } from 'Draw/bonds/strung/StrungElement';
@@ -98,4 +98,42 @@ export function createStrungRectangle(options: StrungElementOptions): StrungRect
     curveLength: options.curveLength,
   });
   return rectangle;
+}
+
+export function createStrungFromStrung(strung: StrungElement, options: StrungElementOptions): StrungElement {
+  let newStrung: StrungElement | undefined = undefined;
+  if (strung.type == 'StrungText') {
+    newStrung =  createStrungText({
+      ...options,
+      text: strung.text.text(),
+    });
+  } else if (strung.type == 'StrungCircle') {
+    newStrung = createStrungCircle(options);
+
+  } else if (strung.type == 'StrungTriangle') {
+    newStrung =  createStrungTriangle(options);
+    newStrung.width = strung.width;
+    newStrung.height = strung.height;
+    newStrung.tailsHeight = strung.tailsHeight;
+    newStrung.rotation = strung.rotation;
+
+  } else if (strung.type == 'StrungRectangle') {
+    newStrung =  createStrungRectangle(options);
+    newStrung.width = strung.width;
+    newStrung.height = strung.height;
+    newStrung.borderRadius = strung.borderRadius;
+    newStrung.rotation = strung.rotation;
+  }
+
+  if (!newStrung) {
+    throw new Error(`Cannot create strung element from strung element of type '${strung.type}'.`);
+  }
+  
+  newStrung.displacementFromCenter = strung.displacementFromCenter;
+  newStrung.displacementFromCurve = strung.displacementFromCurve;
+  repositionStrungElement(newStrung, {
+    curve: options.curve,
+    curveLength: options.curveLength,
+  });
+  return newStrung;
 }

--- a/src/forms/edit/bases/CopyStyleField.tsx
+++ b/src/forms/edit/bases/CopyStyleField.tsx
@@ -1,0 +1,110 @@
+import type { App } from 'App';
+
+import type { Base } from 'Draw/bases/Base';
+
+import * as React from 'react';
+
+import { CopyStyleInput } from 'Forms/edit/svg/CopyStyleInput';
+
+import { FieldLabel } from 'Forms/inputs/labels/FieldLabel';
+
+import { generateHTMLCompatibleUUID } from 'Utilities/generateHTMLCompatibleUUID';
+
+
+type Point = {
+	x: number;
+	y: number;
+  };
+  
+  class BasesWrapper {
+	readonly bases: Base[];
+  
+	constructor(bases: Base[]) {
+	  this.bases = bases;
+	}
+  
+	get textCenters(): Map<Base, Point> {
+	  let textCenters = new Map<Base, Point>();
+	  this.bases.forEach(b => {
+		let textBBox = b.text.bbox();
+		let textCenter = { x: textBBox.cx, y: textBBox.cy };
+		textCenters.set(b, textCenter);
+	  });
+	  return textCenters;
+	}
+  
+	set textCenters(textCenters: Map<Base, Point>) {
+	  this.bases.forEach(b => {
+		let textCenter = textCenters.get(b);
+		if (textCenter) {
+		  b.text.center(textCenter.x, textCenter.y);
+		}
+	  });
+	}
+  }
+
+// should be stable across mountings and unmountings
+// (to facilitate refocusing when the app is refreshed)
+const inputId = generateHTMLCompatibleUUID();
+
+export type Props = {
+  /**
+   * A reference to the whole app.
+   */
+  app: App;
+
+  /**
+   * The bases to edit.
+   */
+  bases: Base[];
+}
+
+export class CopyStyleField extends React.Component<Props> {
+
+	// to be cached on before edit
+	_textCenters?: Map<Base, Point>;
+
+	get bases() {
+		return new BasesWrapper(this.props.bases);
+	}
+
+	handleBeforeEdit() {
+		this._textCenters = this.bases.textCenters; // cache
+
+		this.props.app.pushUndo();
+	}
+
+	handleEdit() {
+		// recenter bases text elements
+		if (this._textCenters) {
+			this.bases.textCenters = this._textCenters;
+			this._textCenters = undefined; // reset
+		}
+
+		this.props.app.refresh(); // refresh after updating all values
+	}
+
+  render() {
+    let style: React.CSSProperties = {
+      marginTop: '8px',
+      alignSelf: 'start',
+      cursor: 'text',
+    };
+
+    return (
+      <FieldLabel style={style} >
+        <CopyStyleInput
+		  		app={this.props.app}
+          id={inputId}
+		  		bases={this.props.bases}
+          onBeforeEdit={() => this.handleBeforeEdit()}
+          onEdit={() => this.handleEdit()}
+          style={{ minWidth: '49px' }}
+        />
+        <span style={{ paddingLeft: '8px' }} >
+          Copy Style
+        </span>
+      </FieldLabel>
+    );
+  }
+}

--- a/src/forms/edit/bases/EditBasesForm.tsx
+++ b/src/forms/edit/bases/EditBasesForm.tsx
@@ -16,6 +16,7 @@ import { FontSizeField } from './FontSizeField';
 import { BoldField } from './BoldField';
 import { ForwardBackwardButtons } from './ForwardBackwardButtons';
 import { OutlineField } from './OutlineField';
+import { CopyStyleField } from './CopyStyleField';
 import { RadiusField as OutlineRadiusField } from './outlines/RadiusField';
 import { StrokeField as OutlineStrokeField } from './outlines/StrokeField';
 import { StrokeWidthField as OutlineStrokeWidthField } from './outlines/StrokeWidthField';
@@ -153,6 +154,7 @@ export function EditBasesForm(props: Props) {
           <FontSizeField {...props} />
           <BoldField {...props} />
           <ForwardBackwardButtons {...props} />
+          <CopyStyleField {...props} />
           <OutlineField {...props} />
           {!props.bases.every(b => b.outline) ? null : (
             <div style={{ margin: '9px 0 0 11px', display: 'flex', flexDirection: 'column' }} >

--- a/src/forms/edit/bonds/primary/CopyStyleField.tsx
+++ b/src/forms/edit/bonds/primary/CopyStyleField.tsx
@@ -1,0 +1,63 @@
+import type { App } from 'App';
+
+import type { Base } from 'Draw/bases/Base';
+
+import * as React from 'react';
+
+import { CopyStyleInput } from 'Forms/edit/svg/CopyStyleInput';
+
+import { FieldLabel } from 'Forms/inputs/labels/FieldLabel';
+
+import { generateHTMLCompatibleUUID } from 'Utilities/generateHTMLCompatibleUUID';
+import { PrimaryBond } from 'Draw/bonds/straight/PrimaryBond';
+
+
+export type Props = {
+  /**
+   * A reference to the whole app.
+   */
+  app: App;
+
+  /**
+   * The bases to edit.
+   */
+  primaryBonds: PrimaryBond[];
+}
+
+// should be stable across mountings and unmountings
+// (to facilitate refocusing when the app is refreshed)
+const inputId = generateHTMLCompatibleUUID();
+
+export class CopyStyleField extends React.Component<Props> {
+  handleBeforeEdit() {
+    this.props.app.pushUndo();
+  }
+
+  handleEdit() {
+    this.props.app.refresh(); // refresh after updating all values
+  }
+
+  render() {
+    let style: React.CSSProperties = {
+      marginTop: '8px',
+      alignSelf: 'start',
+      cursor: 'text',
+    };
+
+    return (
+      <FieldLabel style={style} >
+        <CopyStyleInput
+		      app={this.props.app}
+          id={inputId}
+		      bonds={this.props.primaryBonds}
+          onBeforeEdit={() => this.handleBeforeEdit()}
+          onEdit={() => this.handleEdit()}
+          style={{ minWidth: '49px' }}
+        />
+        <span style={{ paddingLeft: '8px' }} >
+          Copy Style
+        </span>
+      </FieldLabel>
+    );
+  }
+}

--- a/src/forms/edit/bonds/primary/EditPrimaryBondsForm.tsx
+++ b/src/forms/edit/bonds/primary/EditPrimaryBondsForm.tsx
@@ -12,6 +12,7 @@ import { StrokeDasharrayField } from './StrokeDasharrayField';
 import { BasePaddingField } from './BasePaddingField';
 import { StrokeLinecapField } from './StrokeLinecapField';
 import { ForwardBackwardButtons } from './ForwardBackwardButtons';
+import { CopyStyleField } from './CopyStyleField';
 
 import { StrungElementsSection } from 'Forms/edit/bonds/strung/StrungElementsSection';
 
@@ -95,6 +96,7 @@ export function EditPrimaryBondsForm(props: Props) {
           <BasePaddingField {...props} />
           <StrokeLinecapField {...props} />
           <ForwardBackwardButtons {...props} />
+          <CopyStyleField {...props} />
           <div style={{ height: '45px' }} />
           <StrungElementsSection {...props} bonds={props.primaryBonds} />
         </div>

--- a/src/forms/edit/svg/CopyStyleInput.test.js
+++ b/src/forms/edit/svg/CopyStyleInput.test.js
@@ -1,0 +1,238 @@
+import * as React from 'react';
+import { Simulate, act } from 'react-dom/test-utils';
+import { render } from 'react-dom';
+import { unmountComponentAtNode } from 'react-dom';
+
+import { App } from 'App';
+import { NodeSVG } from 'Draw/svg/NodeSVG';
+import { appendSequence } from 'Draw/sequences/add/sequence';
+
+import { CopyStyleInput } from './CopyStyleInput';
+import { StraightBond } from 'Draw/bonds/straight/StraightBond';
+
+let app = null;
+let drawing = null;
+let sequence = null;
+let bases = null;
+let bonds = null;
+
+let container = null;
+
+beforeEach(() => {
+  app = new App({ SVG: { SVG: NodeSVG } });
+  app.appendTo(document.body);
+
+  drawing = app.strictDrawing.drawing;
+  sequence = appendSequence(drawing, { id: 'asdf', characters: 'asdf' });
+
+  bases = [
+    sequence.atPosition(1),
+    sequence.atPosition(2),
+    sequence.atPosition(3),
+    sequence.atPosition(4),
+  ];
+
+  let line = app.strictDrawing.svg.line(30, 50, 100, 500);
+
+  bonds = [
+    new StraightBond(line, bases[0], bases[1]),
+    new StraightBond(line, bases[1], bases[2]),
+    new StraightBond(line, bases[2], bases[3]),
+  ];
+
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  unmountComponentAtNode(container);
+  container.remove();
+  container = null;
+
+  bases = null;
+  sequence = null;
+  drawing = null;
+
+  app.remove();
+  app = null;
+});
+
+describe('CopyStyleInput component', () => {
+  test('id prop', () => {
+    act(() => render(
+      <CopyStyleInput id='asdfFDsa321' />,
+      container,
+    ));
+
+    expect(container.firstChild.id).toBe('asdfFDsa321');
+  });
+
+  describe('copying the attributes of bases', () => {
+    test('when the input value is less than 0', () => {
+      let old_bases = bases.slice();
+      act(() => render(
+        <CopyStyleInput
+          app={app}
+          bases={bases}
+        />,
+        container,
+      ));
+      container.firstChild.value = '-1';
+      Simulate.change(container.firstChild);
+      Simulate.blur(container.firstChild);
+      // I expect no changes in bases vs old_bases
+      expect(bases.every((base, i) => base === old_bases[i])).toBeTruthy();
+    });
+
+    test('when the input value is higher than the number of bases', () => {
+      let old_bases = bases.slice();
+      act(() => render(
+        <CopyStyleInput
+          app={app}  		
+          bases={bases}
+        />,
+        container,
+      ));
+
+      container.firstChild.value = '123678';
+      Simulate.change(container.firstChild);
+      Simulate.blur(container.firstChild);
+      // I expect no changes in bases vs old_bases
+      expect(bases.every((base, i) => base === old_bases[i])).toBeTruthy();
+    });
+
+    test('when the input value is empty', () => {
+      let old_bases = bases.slice();
+      act(() => render(
+        <CopyStyleInput
+          app={app}
+          bases={bases}
+        />,
+        container,
+      ));
+
+      container.firstChild.value = '       ';
+      Simulate.change(container.firstChild);
+      Simulate.blur(container.firstChild);
+      // I expect no changes in bases vs old_bases
+      expect(bases.every((base, i) => base === old_bases[i])).toBeTruthy();
+    });
+
+    test('when the input value is a valid index', () => {
+      // Modify the fill of the third base
+      bases[2].text = bases[2].text.attr("fill", "#00ff00");
+      let pass_bases = bases.slice(0, 2);  // Copy only to the first two bases
+      act(() => render(
+        <CopyStyleInput
+          app={app}
+          bases={pass_bases} 
+        />,
+        container,
+      ));
+
+      container.firstChild.value = '3';
+      Simulate.change(container.firstChild);
+      Simulate.blur(container.firstChild);
+      expect(
+        pass_bases.every(base => base.text.attr('fill') === "#00ff00")
+      ).toBeTruthy();
+    });
+
+    test('when you copy twice, i.e. it resets the setting', () => {
+      // Modify the fill of the third base
+      bases[2].text = bases[2].text.attr("fill", "#00ff00");
+      let pass_bases = bases.slice(0, 2);  // Copy only to the first two bases
+      act(() => render(
+        <CopyStyleInput
+          app={app}
+          bases={pass_bases} 
+        />,
+        container,
+      ));
+
+      container.firstChild.value = '3';  // Copy from the third base (idx 2)
+      Simulate.change(container.firstChild);
+      Simulate.keyUp(container.firstChild, { key: 'Enter' });
+
+      container.firstChild.value = '4';  // Copy from the fourth base (idx 3)
+      Simulate.change(container.firstChild);
+      Simulate.keyUp(container.firstChild, { key: 'Enter' });
+
+      expect(
+        pass_bases.every(base => base.text.attr('fill') === "black")
+      ).toBeTruthy();
+    });
+  });
+
+  describe('copying the attributes of bonds', () => {
+    test('when the input value is less than 0', () => {
+      let old_bonds = bonds.slice();
+      act(() => render(
+        <CopyStyleInput
+          app={app}
+          bonds={bonds}
+        />,
+        container,
+      ));
+      container.firstChild.value = '-1';
+      Simulate.change(container.firstChild);
+      Simulate.blur(container.firstChild);
+      // I expect no changes in bonds vs old_bases
+      expect(bonds.every((bond, i) => bond === old_bonds[i])).toBeTruthy();
+    });
+
+    test('when the input value is higher than the number of bases', () => {
+      let old_bonds = bonds.slice();
+      act(() => render(
+        <CopyStyleInput
+          app={app}
+          bonds={bonds}
+        />,
+        container,
+      ));
+      container.firstChild.value = '1123678';
+      Simulate.change(container.firstChild);
+      Simulate.blur(container.firstChild);
+      // I expect no changes in bonds vs old_bases
+      expect(bonds.every((bond, i) => bond === old_bonds[i])).toBeTruthy();
+    });
+
+    test('when the input value is empty', () => {
+      let old_bonds = bonds.slice();
+      act(() => render(
+        <CopyStyleInput
+          app={app}
+          bonds={bonds}
+        />,
+        container,
+      ));
+      container.firstChild.value = '      ';
+      Simulate.change(container.firstChild);
+      Simulate.blur(container.firstChild);
+      // I expect no changes in bonds vs old_bases
+      expect(bonds.every((bond, i) => bond === old_bonds[i])).toBeTruthy();
+    });
+
+    test('when the input value is a valid index', () => {
+      // Modify the fill of the third base
+      bonds[2].line = bonds[2].line.attr("fill", "#00ff00");
+      let pass_bonds = bonds.slice(0, 2);  // Copy only to the first two bases
+      act(() => render(
+        <CopyStyleInput
+          app={app}
+          bonds={pass_bonds} 
+        />,
+        container,
+      ));
+
+      container.firstChild.value = '3';
+      Simulate.change(container.firstChild);
+      Simulate.blur(container.firstChild);
+      expect(
+        pass_bonds.every(bond => bond.line.attr('fill') === "#00ff00")
+      ).toBeTruthy();
+    });
+
+  });
+
+});

--- a/src/forms/edit/svg/CopyStyleInput.tsx
+++ b/src/forms/edit/svg/CopyStyleInput.tsx
@@ -1,0 +1,255 @@
+import * as SVG from '@svgdotjs/svg.js';
+
+import * as React from 'react';
+
+import { TextInput } from 'Forms/inputs/text/TextInput';
+import type { CSSProperties } from 'Forms/inputs/text/TextInput';
+import { App } from 'App';
+import { CircleBaseOutline } from 'Draw/bases/outlines/circle/CircleBaseOutline';
+import { Base } from 'Draw/bases/Base';
+import { addCircleOutline, removeCircleOutline } from 'Draw/bases/outlines/circle/add';
+import { setValues as setValuesOutline, values } from 'Draw/bases/outlines/circle/values';
+import { PrimaryBond } from 'Draw/bonds/straight/PrimaryBond';
+import { addStrungElementToBond, removeStrungElementFromBond } from 'Draw/bonds/strung/addToBond';
+import { curveOfBond } from 'Draw/bonds/strung/curveOfBond';
+import { curveLengthOfBond } from 'Draw/bonds/strung/curveLengthOfBond';
+import { createStrungFromStrung } from 'Draw/bonds/strung/create';
+import { StrungElement } from 'Draw/bonds/strung/StrungElement';
+import { svgElementOfStrungElement } from '../bonds/strung/svgElementOfStrungElement';
+import { setValues as setValuesBase } from 'Draw/bases/values';
+
+let NonCopyableBaseAttributes = [
+  "id", "x", "y"
+];
+let NonCopyableBondAttributes = [
+  "id", "x1", "x2", "y1", "y2"
+];
+let NonCopyableStrungAttributes = [
+  "id", "cx", "cy", "d", "x", "y"
+];
+
+class BaseWrapper {
+  readonly base: Base;
+
+  constructor(base: Base | undefined) {
+    if (typeof base == 'undefined') {
+      throw new Error();
+    }
+    this.base = base;
+  }
+
+  get text(): SVG.Text {
+    return this.base.text;
+  }
+
+  get outline(): CircleBaseOutline | undefined {
+    return this.base.outline;
+  }
+
+  get circle(): SVG.Circle | undefined {
+    return this.outline?.circle;
+  }
+}
+
+class StrungWrapper {
+  readonly strung: StrungElement;
+
+  constructor(strung: StrungElement | undefined) {
+    if (typeof strung == 'undefined') {
+      throw new Error();
+    }
+    this.strung = strung;
+  }
+
+  get element(): SVG.Element {
+    if (this.strung.type == 'StrungText') {
+      return this.strung.text;
+    } else if (this.strung.type == 'StrungCircle') {
+      return this.strung.circle;
+    } else {
+      return this.strung.path;
+    }
+  }
+}
+
+export type Props = {
+  app: App;
+  id?: string;
+
+  /**
+   * The elements to edit.
+   */
+  bases?: Base[];
+  bonds?: PrimaryBond[];
+
+  /**
+   * Called immediately after editing the elements.
+   */
+  onEdit?: () => void;
+
+  /**
+   * Called immediately before editing the elements.
+   */
+  onBeforeEdit?: () => void;
+
+  style?: CSSProperties;
+};
+
+export class CopyStyleInput extends React.Component<Props> {
+  state: {
+    value: string;
+  };
+
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      value: "",
+    };
+  }
+
+  render() {
+    return (
+      <TextInput
+        id={this.props.id}
+        value={this.state.value}
+        onChange={event => this.setState({ value: event.target.value })}
+        onBlur={() => this.submit()}
+        onKeyUp={event => {
+          if (event.key.toLowerCase() == 'enter') {
+            this.submit();
+          }
+        }}
+        spellCheck={false}
+        style={{
+          minWidth: '49px',
+          ...this.props.style,
+        }}
+      />
+    );
+  }
+
+  copyBaseStyle(idx_copy: number) {
+    if (idx_copy < 1 || idx_copy > this.props.app.strictDrawing.drawing.numBases) {  // idx_copy goes from 1 to numBases to make it easier for the user.
+      return; // don't edit the SVG elements
+    }
+    let copyBase = this.props.app.strictDrawing.drawing.getBaseAtOverallPosition(idx_copy);
+    let copyBaseWrapped = new BaseWrapper(copyBase);
+
+    this.props.bases?.forEach(base => {
+      // Reset the base to the default values. This is necessary because in saved files, fill is not an attribute of the base by default.
+      setValuesBase(base, Base.recommendedDefaults);
+
+      // Change the text attributes
+      Object.keys(copyBaseWrapped.text.attr()).forEach(function (attributeName) {
+        var attributeValue = copyBaseWrapped.text.attr(attributeName);
+
+        // We don't want to copy the id attribute, or the center of the box:
+        // Copying the ID means linking the style of both. I don't know if that's useful in any way. TODO: Button to link styles?
+        if (NonCopyableBaseAttributes.includes(attributeName)) {
+          return;
+        }
+        base.text.attr(attributeName, attributeValue);
+      });
+
+      // Change the outline attributes
+      if (base.outline) {
+        // Remove whatever this base has
+        removeCircleOutline(base);
+      }
+
+      if (copyBaseWrapped.outline) {
+        if (!base.outline) {
+          addCircleOutline(base);
+        }
+        if (base.outline) {
+          setValuesOutline(base.outline, values(copyBaseWrapped.outline));
+          base.outline.sendToBack();
+        }
+      }
+    });
+  }
+
+  copyBondStyle(idx_copy: number) {
+    if (idx_copy < 1 || idx_copy > this.props.app.strictDrawing.drawing.primaryBonds.length) {
+      return; // don't edit the SVG elements
+    }
+    // They have line: SVG.Line, strungElements: StrungElement[] and basePadding: number
+    let copyBond = this.props.app.strictDrawing.drawing.primaryBonds[idx_copy - 1];
+
+    this.props.bonds?.forEach(bond => {
+      // Change the line attributes
+      Object.keys(copyBond.line.attr()).forEach(function (attributeName) {
+        var attributeValue = copyBond.line.attr(attributeName);
+
+        // We don't want to copy the id attribute, or the coordinates of the line:
+        // Copying the ID means linking the style of both. I don't know if that's useful in any way.
+        if (NonCopyableBondAttributes.includes(attributeName)) {
+          return;
+        }
+        bond.line.attr(attributeName, attributeValue);
+      });
+
+      // Change the base padding:
+      bond.basePadding1 = copyBond.basePadding1;
+      bond.basePadding2 = copyBond.basePadding2;
+
+      // Change the strungElements attributes
+      // Remove whatever this bond has
+      bond.strungElements.forEach(function (strungElement) {
+        removeStrungElementFromBond({ bond, strungElement });
+      });
+
+      // Add whatever the copy has      
+      copyBond.strungElements.forEach(function (strungElement) {
+        let curve = curveOfBond(bond);
+        let curveLength = curveLengthOfBond(bond);
+        let newStrung: StrungElement | undefined;
+
+        if (curve) {
+          newStrung = createStrungFromStrung(strungElement, { curve, curveLength });
+        }
+
+        let strungElementWrapped = new StrungWrapper(newStrung);
+
+        // Edit the attributes of the strung element
+        let svgCopyElements = svgElementOfStrungElement(strungElement);
+        Object.keys(svgCopyElements.attr()).forEach(function (attributeName) {
+          var attributeValue = svgCopyElements.attr(attributeName);
+
+          // Copying the ID means linking the style of both. I don't know if that's useful in any way.
+          if (NonCopyableStrungAttributes.includes(attributeName)) {
+            return;
+          }
+          strungElementWrapped.element.attr(attributeName, attributeValue);
+        });
+        
+        addStrungElementToBond({ bond, strungElement: strungElementWrapped.strung });
+        
+      });
+      console.log(bond.strungElements);
+    });
+  }
+
+  submit() {
+    let newValue = Number.parseFloat(this.state.value);
+    if (Number.isNaN(newValue)) {
+      return; // don't edit the SVG elements
+    }
+
+    if (this.props.onBeforeEdit) {
+      this.props.onBeforeEdit();
+    }
+
+    if (this.props.bases) {
+      this.copyBaseStyle(newValue);
+    } else if (this.props.bonds) {
+      this.copyBondStyle(newValue);
+    }
+
+    // Now we should recenter the text element in case it was resized:
+    if (this.props.onEdit) {
+      this.props.onEdit();
+    }
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,6 +29,11 @@ import { waitMilliseconds } from 'Time/waitMilliseconds';
 import { waitUntil } from 'Time/waitUntil';
 import { ElapsedTimeCalculator } from 'Time/ElapsedTimeCalculator';
 
+if (module.hot) {
+  module.hot.accept();
+}
+
+
 let timeOnPageCalculator = new ElapsedTimeCalculator();
 timeOnPageCalculator.restartCounting();
 

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -3,7 +3,7 @@ const CircularDependencyPlugin = require('circular-dependency-plugin');
 const webpack = require("webpack");
 
 module.exports = {
-  mode: 'production',
+  mode: 'development',
   entry: './src/index.tsx',
   output: {
     filename: 'bundle.js',
@@ -59,7 +59,14 @@ module.exports = {
       },
       {
         test: /\.tsx?$/,
-        use: 'ts-loader',
+        use: [
+          {
+            loader: 'ts-loader',
+            options: {
+              transpileOnly: false
+            }
+          }
+        ],
         exclude: /node_modules/
       }
     ]
@@ -89,5 +96,8 @@ module.exports = {
     },
     modules: ['node_modules'],
     extensions: [ '.tsx', '.ts', '.js' ]
-  }
+  },
+  performance: {
+    hints: false
+  },
 }


### PR DESCRIPTION
Added a text field to the base and primary bond edit menus to copy the style from another base or bond. The input is the base/bond number as shown in the app (from 1 to numBases). 

Added some tests to make sure everything worked as it should. Feel free to move them somewhere else if `src/forms/edit/svg/CopyStyleInput.test.js` doesn't look like the right path.

Reference to issue #2 